### PR TITLE
Enable .pdb files for Release config & add AzDO build script

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -1,0 +1,40 @@
+name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
+
+trigger:
+  - master
+  - refs/tags/*
+
+pr:
+  - master
+
+resources:
+  repositories:
+    - repository: internal-templates
+      type: github
+      name: xamarin/yaml-templates
+      endpoint: xamarin
+    - repository: components
+      type: github
+      name: xamarin/XamarinComponents
+      endpoint: xamarin
+
+jobs:
+  - template: .ci/build.yml@components
+    parameters:
+      publishJob: windows
+      buildType: none
+      areaPath: 'DevDiv\Xamarin SDK'
+      linuxImage: '' # skip linux builds
+      skipValidation: true
+      steps:
+        - task: MSBuild@1
+          displayName: msbuild LineEditor.sln
+          inputs:
+            solution: LineEditor.sln
+            configuration: Release
+            msbuildArguments: /restore /t:Pack /p:PackageOutputPath=$(Build.SourcesDirectory)/output
+
+  - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
+    - template: sign-artifacts/jobs/v1.yml@internal-templates
+      parameters:
+        dependsOn: [ 'build' ]

--- a/LineEditor/LineEditor.csproj
+++ b/LineEditor/LineEditor.csproj
@@ -14,23 +14,15 @@
     <Title>Mono.Terminal - LineEdit, GetLine</Title>
     <Description>Interactive Command Line Editor</Description>
     <InferPackageContents>false</InferPackageContents>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DocumentationFile>bin\Debug\netstandard2.0\LineEditor.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType></DebugType>
     <DocumentationFile>bin\Release\netstandard2.0\LineEditor.xml</DocumentationFile>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.0" />
-  </ItemGroup>
-
-  <!-- Workaround for 'Nugetizer packs reference assemblies into NuGet package' issue -->
-  <!-- https://github.com/NuGet/Home/issues/5800 -->
-  <ItemGroup>
-    <PackageFile Include="$(OutputPath)LineEditor.dll" PackagePath="lib/netstandard2.0/LineEditor.dll" />
-    <PackageFile Include="$(OutputPath)LineEditor.xml" PackagePath="lib/netstandard2.0/LineEditor.xml" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1230070
Context: https://github.com/xamarin/XamarinComponents/blob/af66a9ea9536116b1cdcdd4bcc499f5fcb7232ea/.ci/build.yml

Current Microsoft practice requires the presence of symbol files
*somewhere* in order to provide useful stack traces in telemetry/etc.
The easiest way to have the symbol files is to (1) *create them*, and
(2) redistribute them within NuGet packages (so that e.g. the
Xamarin.Android SDK can in turn redistribute the `.pdb` files...)

Update `LineEditor.csproj` so that `$(DebugType)` is *not* cleared in
the Release configuration.  This satisfies (1): create the symbol
files, so that they *exist*.

Update `LineEditor.csproj` to remove the `@(PackageReference)` to
`NuGet.Build.Packaging` and the `@(PackageFile)` item group, and
instead require the use of the `msbuild /t:Pack` command, which does
things *mostly* right.

Where `msbuild /t:Pack` falls down is that `LineEditor.pdb` isn't
included into the `.nupkg` file, which is something @jonpryor desires,
to make it easier to include `LineEditor.pdb` into the Xamarin.Android
`.pdb`/`.vsix` installers.

To cause `LineEditor.pdb` to be included in the `.nupkg` file,
override the `$(AllowedOutputExtensionsInPackageBuildOutputFolder)`
property to include `.pdb`.

Finally, add `.ci/azure-pipelines.yml`, which is a YAML build script
for Azure Pipelines.  `azure-pipelines.yml` uses the `.ci/build.yml`
file from xamarin/XamarinComponents for signing and publishing.