### PR TITLE
Fix NuGet publishing errors

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
       buildType: none
       areaPath: 'DevDiv\Xamarin SDK'
       linuxImage: '' # skip linux builds
-      skipValidation: true
+      validPackagePrefixes: [ 'Mono' ]
       steps:
         - task: MSBuild@1
           displayName: msbuild LineEditor.sln

--- a/LineEditor/LineEditor.csproj
+++ b/LineEditor/LineEditor.csproj
@@ -4,12 +4,14 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Mono.Terminal</PackageId>
     <PackageVersion>5.4.1</PackageVersion>
-    <Authors>Miguel de Icaza</Authors>
+    <Authors>Microsoft</Authors>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageIconUrl>https://github.com/mono/LineEditor/raw/master/icon_128x128.png</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/mono/LineEditor/blob/master/LICENSE</PackageLicenseUrl>
     <Owners>Xamarin</Owners>
     <PackageProjectUrl>https://github.com/mono/LineEditor</PackageProjectUrl>
-    <PackageReleaseNotes>Release 5.4.0 includes new documentation.</PackageReleaseNotes>
+    <PackageReleaseNotes>Release 5.4.1 improves Windows support.</PackageReleaseNotes>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Summary>An interactive commmand line editor</Summary>
     <Title>Mono.Terminal - LineEdit, GetLine</Title>
     <Description>Interactive Command Line Editor</Description>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/975/Publishing-a-NuGet-package?anchor=troubleshooting-package-publishing-errors

While attempting to use the internal publishing pipeline part of
bce1b7f3, we encountered an error regarding the `.nuspec` file:

	The nuget command failed with exit code(1) and error:
	Response status code does not indicate success: 400
	(The package is not compliant with metadata requirements for Microsoft
	packages on NuGet.org. Go to https://aka.ms/Microsoft-NuGet-Compliance
	for more information. Policy violations: The package metadata defines
	'Miguel de Icaza' as one of the authors which is not allowed by policy.
	The package metadata contains a non-compliant copyright element.).

Update the `$(Authors)` property and add a `$(Copyright)` property so
that the resulting `.nupkg` file is compliant.